### PR TITLE
Add issue authoring standards: problem first, solutions in comments

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -67,6 +67,15 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | grep -q 'gh issue create'; then echo 'Reminder: Issue body = problem statement + repro case. Post solution ideas and implementation plans as comments after creation.'; fi"
+          }
+        ]
+      },
+      {
         "matcher": "Task",
         "hooks": [
           {

--- a/skills/documentation-maintenance/SKILL.md
+++ b/skills/documentation-maintenance/SKILL.md
@@ -104,6 +104,37 @@ Before committing documentation changes:
 | **Accuracy** | Tested code examples, correct syntax | Pseudocode as real code, "might work" |
 | **Completeness** | Prerequisites, outcomes, gotchas | Assuming knowledge, skipping error cases |
 
+## Issue Authoring
+
+**Issue body = problem, not solution.**
+
+The issue body describes *what's wrong*. Solution ideas, feature requests, and implementation plans go in **comments** after the issue is created.
+
+| Content | Issue body | Comments |
+|---------|:---:|:---:|
+| Problem statement | ✅ | |
+| Minimal repro case | ✅ | |
+| Impact (who, how often, severity) | ✅ | |
+| Solution ideas | | ✅ |
+| Feature requests | | ✅ |
+| Implementation plans / task lists | | ✅ |
+
+**Why:** Separating problem from solution prevents anchoring on a particular approach before the problem is fully understood. Solutions can evolve in comments without rewriting the issue.
+
+**Template:**
+```markdown
+## Problem
+[Observable behavior vs expected behavior]
+
+## Repro (if applicable)
+[Minimal code, steps, or failing test]
+
+## Impact
+[Who's affected, how often, severity]
+```
+
+---
+
 ## Templates
 
 ### New Skill


### PR DESCRIPTION
## Summary

- PostToolUse hook reminds on `gh issue create` that body should be problem + repro case
- Issue authoring section added to `documentation-maintenance` skill with template and content placement table
- Feedback memory saved for cross-session persistence

**Rule:** Issue body = problem statement + repro case. Solutions, feature requests, and implementation plans go in comments.

## Test plan

- [ ] Run `gh issue create` in a project and verify reminder appears
- [ ] Read documentation-maintenance skill and verify issue authoring section

🤖 Generated with [Claude Code](https://claude.com/claude-code)