### PR TITLE
feat: extract PDCA cycle into portable plugin skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The plugin provides hooks for PDCA workflow automation:
 | PDCA plan transition | `PreToolUse:EnterPlanMode` | Transition issue to `pdca:plan`, print PDCA reminder |
 | Principles check | `PreToolUse:ExitPlanMode` | Validate plan against project principles before execution |
 | Decomplection review | `PreToolUse:ExitPlanMode` | Gate plan finalization with decomplection checklist |
+| Derisk gate | `PreToolUse:ExitPlanMode` | Loop /derisk until all risks are LOW before execution |
 | Block local plans | `PreToolUse:Write` | Prevent creating local plan files (forces GitHub Issues) |
 | Issue stack display | `PreToolUse:Bash\|Task\|Edit` | Show current issue stack context |
 | Git commit reminder | `PostToolUse:Bash` | Remind to update issue stack on commit |

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -29,6 +29,15 @@
         ]
       },
       {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/derisk-on-exit-plan.sh"
+          }
+        ]
+      },
+      {
         "matcher": "Bash|Task|Edit",
         "hooks": [
           {

--- a/scripts/derisk-on-exit-plan.sh
+++ b/scripts/derisk-on-exit-plan.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# Derisk gate — runs on ExitPlanMode.
+# First call: denies and instructs Claude to run /derisk loop.
+# Second call: allows through (derisking presumed done).
+
+# Find the most recent plan file
+PLAN_DIR="${CLAUDE_PROJECT_DIR:-.}/.claude/plans"
+PLAN_FILE=$(ls -t "$PLAN_DIR"/*.md 2>/dev/null | head -1)
+
+if [ -z "$PLAN_FILE" ]; then
+  # No plan file found — allow through
+  exit 0
+fi
+
+# Marker file: hash of plan file path for uniqueness
+MARKER_DIR="/tmp/claude-derisk-review"
+mkdir -p "$MARKER_DIR"
+PLAN_HASH=$(echo "$PLAN_FILE" | shasum -a 256 | cut -d' ' -f1)
+MARKER_FILE="$MARKER_DIR/$PLAN_HASH"
+
+if [ -f "$MARKER_FILE" ]; then
+  # Already derisked — allow and clean up
+  rm -f "$MARKER_FILE"
+  exit 0
+fi
+
+# First attempt — create marker and deny with derisk instructions
+touch "$MARKER_FILE"
+
+cat <<'ENDJSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "DERISK REQUIRED\n\nBefore finalizing this plan, run /derisk to identify and validate unvalidated assumptions.\n\nLoop until ALL risks are LOW or further derisking is not possible:\n1. Identify unvalidated assumptions in the plan\n2. Validate critical assumptions at the REPL\n3. If a risk cannot be reduced, document why\n4. If any HIGH risks remain that cannot be derisked, STOP and ask the user for guidance\n\nWhen all risks are LOW (or user has approved remaining risks), call ExitPlanMode again."
+  }
+}
+ENDJSON

--- a/skills/pdca-cycle/SKILL.md
+++ b/skills/pdca-cycle/SKILL.md
@@ -131,6 +131,7 @@ The plugin provides automation hooks for PDCA transitions:
 | `pdca-plan-on-enter-plan-mode.sh` | PreToolUse:EnterPlanMode | Transitions label to `pdca:plan` |
 | `plan-principles-check.sh` | PreToolUse:ExitPlanMode | Validates plan principles |
 | `decomplection-review.sh` | PreToolUse:ExitPlanMode | Gates exit with decomplection checklist |
+| `derisk-on-exit-plan.sh` | PreToolUse:ExitPlanMode | Loops /derisk until all risks are LOW |
 | PostToolUse:Task | PostToolUse:Task | Prompts Check phase when Do tasks complete |
 | Stop | Stop | Checks PDCA phase and prompts next action |
 


### PR DESCRIPTION
## Summary

- Extracts PDCA methodology from project-specific CLAUDE.md into reusable `pdca-cycle` skill
- All four phases with clear requirements and checklists
- Halt-on-violated-assumptions rule
- Gap analysis template for Check phase
- Lessons learned guidance
- Phase transition mechanics (label = source of truth, stack = cache)
- References existing plugin hooks that automate transitions
- Issue authoring integrated (problem first, plan in comments)

## Test plan

- [ ] Verify skill triggers on "how do I track this complex feature"
- [ ] Verify hook references in skill match actual hooks in hooks.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)