### PR TITLE
feat: add status line script

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,28 @@ The plugin provides hooks for PDCA workflow automation:
 | `plan-principles-check.sh` | Principles review before plan finalization |
 | `block-local-plans.sh` | Prevent local plan file creation |
 | `decomplection-review.sh` | Gate plan exit with decomplection checklist |
+| `derisk-on-exit-plan.sh` | Loop /derisk until all risks are LOW before execution |
+| `statusline.sh` | Status line showing issue stack, PDCA phase, model, context % |
+
+## Status Line
+
+The plugin ships a status line script. To enable, add to your project or user `settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "<path-to-plugin>/scripts/statusline.sh"
+  }
+}
+```
+
+**Displays:** `[Model] #52 (do) | 23% ctx | $1.45`
+
+- Current model name
+- Top issue from stack + PDCA phase
+- Context window usage
+- Session cost
 
 ## Project Setup Requirements
 

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Pyze plugin status line — shows issue stack, PDCA phase, model, and context usage.
+#
+# Install by adding to your settings.json (project or user level):
+#   "statusLine": {
+#     "type": "command",
+#     "command": "${CLAUDE_PLUGIN_ROOT}/scripts/statusline.sh"
+#   }
+#
+# Or copy this script and customize.
+
+set -euo pipefail
+
+input=$(cat)
+MODEL=$(echo "$input" | jq -r '.model.display_name // "unknown"')
+PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
+
+# Issue stack — read top issue from local file
+ISSUE_INFO=""
+STACK_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/issue-stack.md"
+if [ -f "$STACK_FILE" ]; then
+  TOP=$(grep -E '^- #' "$STACK_FILE" | head -1)
+  if [ -n "$TOP" ]; then
+    # Extract: "- #52 — Fix auth (do)" → "#52 (do)"
+    ISSUE_NUM=$(echo "$TOP" | grep -oE '#[0-9]+' | head -1)
+    PHASE=$(echo "$TOP" | grep -oE '\([a-z]+\)$' || echo "")
+    if [ -n "$ISSUE_NUM" ]; then
+      ISSUE_INFO=" ${ISSUE_NUM} ${PHASE}"
+    fi
+  fi
+fi
+
+# Cost (if available)
+COST=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
+if [ "$COST" != "0" ] && [ -n "$COST" ]; then
+  COST_FMT=$(printf '$%.2f' "$COST")
+else
+  COST_FMT=""
+fi
+
+# Build output
+OUTPUT="[${MODEL}]"
+
+if [ -n "$ISSUE_INFO" ]; then
+  OUTPUT="${OUTPUT}${ISSUE_INFO} |"
+fi
+
+OUTPUT="${OUTPUT} ${PCT}% ctx"
+
+if [ -n "$COST_FMT" ]; then
+  OUTPUT="${OUTPUT} | ${COST_FMT}"
+fi
+
+echo "$OUTPUT"


### PR DESCRIPTION
## Summary

- New `scripts/statusline.sh` showing issue stack, PDCA phase, model, context %, and cost
- Opt-in via `statusLine` setting in settings.json
- Reads `.claude/issue-stack.md` for current issue and phase (no API calls)

**Display:** `[Model] #52 (do) | 23% ctx | $1.45`

## Test plan

- [ ] Add statusLine config to settings.json, verify display
- [ ] Test with empty issue stack — shows `[Model] | 23% ctx`
- [ ] Test with populated stack — shows issue number and phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)